### PR TITLE
[#23 #24] As the API, I can determine the pagination results and keyword search results

### DIFF
--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -26,6 +26,12 @@ module Api
         end
       end
 
+      def show
+        keyword = current_user.keywords.find show_params[:id]
+
+        render json: KeywordSerializer.new(keyword, include: [:links], params: { show: true })
+      end
+
       private
 
       def keywords_form
@@ -42,6 +48,10 @@ module Api
 
       def indexable_params
         params.permit(%i[keyword url])
+      end
+
+      def show_params
+        params.permit(:id)
       end
     end
   end

--- a/app/controllers/api/v1/pagy/jsonapi_concern.rb
+++ b/app/controllers/api/v1/pagy/jsonapi_concern.rb
@@ -1,0 +1,36 @@
+module Api
+  module V1
+    module Pagy
+      module JsonapiConcern
+        private
+
+        def pagy_options(pagy)
+          {
+            meta: { total_pages: pagy.pages },
+            links: pagy_options_links(pagy)
+          }
+        end
+
+        def pagy_options_links(pagy)
+          {
+            first: url_for_page(1),
+            self: url_for_page(pagy.page),
+            next: url_for_page(pagy.next),
+            prev: url_for_page(pagy.prev),
+            last: url_for_page(pagy.last)
+          }
+        end
+
+        def url_for_page(page)
+          return nil unless page
+
+          url_for only_path: false, params: jsonapi_params.merge(page: page)
+        end
+
+        def jsonapi_params
+          params.permit(:page, :sort, :filter)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/pagy/jsonapi_concern.rb
+++ b/app/controllers/api/v1/pagy/jsonapi_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V1
     module Pagy

--- a/app/presenters/keyword_presenter.rb
+++ b/app/presenters/keyword_presenter.rb
@@ -25,6 +25,10 @@ class KeywordPresenter
     keyword.created_at.strftime('%F %H:%M:%S')
   end
 
+  def updated_at
+    keyword.updated_at.strftime('%F %H:%M:%S')
+  end
+
   def raw_html
     keyword.html
   end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -8,5 +8,5 @@ class KeywordSerializer
 
   attribute :html, if: proc { |_, params| params[:show] }
 
-  has_many :result_links, if: proc { |_, params| params[:show] }
+  has_many :links, if: proc { |_, params| params[:show] }
 end

--- a/app/serializers/link_serializer.rb
+++ b/app/serializers/link_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LinkSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/link_serializer.rb
+++ b/app/serializers/link_serializer.rb
@@ -1,0 +1,5 @@
+class LinkSerializer
+  include JSONAPI::Serializer
+
+  attributes :url, :link_type, :created_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :registrations, only: [:index, :create]
-      resources :keywords, only: [:index, :create]
+      resources :keywords, only: [:index, :create, :show]
     end
   end
 

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -14,6 +14,52 @@ describe Api::V1::KeywordsController, type: :request do
 
       expect(json_response[:data].count).to eq(10)
     end
+
+    it 'does not display the HTML attribute' do
+      user = Fabricate(:user)
+      Fabricate.times(10, :keyword, user: user)
+
+      create_token_header(user)
+
+      get :index
+
+      expect(json_response[:data].first[:attributes].keys).not_to include(:html)
+    end
+
+    it 'does not include any additional data such as the result_links' do
+      user = Fabricate(:user)
+      Fabricate.times(10, :keyword, user: user)
+
+      create_token_header(user)
+
+      get :index
+
+      expect(json_response[:included]).to be_nil
+    end
+  end
+
+  context 'given multiple pages of keywords' do
+    it 'returns the first page of keywords' do
+      user = Fabricate(:user)
+      Fabricate.times(31, :keyword, user: user)
+
+      create_token_header(user)
+
+      get :index
+
+      expect(json_response[:data].count).to eq(30)
+    end
+
+    it 'returns the total_pages meta info' do
+      user = Fabricate(:user)
+      Fabricate.times(31, :keyword, user: user)
+
+      create_token_header(user)
+
+      get :index
+
+      expect(json_response[:meta][:total_pages]).to eq(2)
+    end
   end
 
   context 'given an unauthenticated user' do


### PR DESCRIPTION
Closes #23 
Closes #24 

## What happened 👀

✅ Created pagination using Pagy
✅ Ensured searching feature is working
✅ Built a route that allows to see the attributes of a keyword

## Insight 📝

~

## Proof Of Work 📹
<img width="568" alt="Screen Shot 2022-11-02 at 3 31 00 PM" src="https://user-images.githubusercontent.com/28055566/199438826-4015ff2f-4c3f-4520-a882-33b352f0086b.png">

<img width="467" alt="Screen Shot 2022-11-02 at 3 32 44 PM" src="https://user-images.githubusercontent.com/28055566/199439159-3a2252a0-e582-46f6-9c57-a19a61f3b13a.png">

Show us the implementation: screenshots, GIFs, etc.
